### PR TITLE
Employ type-specific adapter on save when it exists

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -830,14 +830,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   save: function() {
-    var adapter = this.constructor.adapter;
+    var type = this.get('type');
+    var owner = Ember.getOwner(this);
+    var typeAdapter = owner.lookup('adapter:' + type);
+    var adapter = typeAdapter || this.constructor.adapter;
     // This is a hack for Copilot to ensure at runtime that the correct
     // serializer is used for the given type. This is not always the case
     // because of how Ember Model caches the serilizer/adapter types
     // and the use of polymorphic relationships
-    var type = this.get('type');
     if (type) {
-      var store = Ember.getOwner(this).lookup('service:store');
+      var store = owner.lookup('service:store');
       var serializer = store.serializerFor(type);
       adapter.set('serializer', serializer);
     }

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -263,14 +263,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   save: function() {
-    var adapter = this.constructor.adapter;
+    var type = this.get('type');
+    var owner = Ember.getOwner(this);
+    var typeAdapter = owner.lookup('adapter:' + type);
+    var adapter = typeAdapter || this.constructor.adapter;
     // This is a hack for Copilot to ensure at runtime that the correct
     // serializer is used for the given type. This is not always the case
     // because of how Ember Model caches the serilizer/adapter types
     // and the use of polymorphic relationships
-    var type = this.get('type');
     if (type) {
-      var store = Ember.getOwner(this).lookup('service:store');
+      var store = owner.lookup('service:store');
       var serializer = store.serializerFor(type);
       adapter.set('serializer', serializer);
     }


### PR DESCRIPTION
This is required by Copilot because in the runwaymoments routes we load both a runwaymoment and photo model, but their `serializer` properties are stored on a shared adapter which results in the correct normalization for runwaymoment being bypassed.