### PR TITLE
Fix notifyPropertyChange on hasMany clearing data

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -1575,6 +1575,8 @@ Ember.hasMany = function(type, options) {
 
 Ember.Model.reopen({
   getHasMany: function(key, type, meta, owner) {
+    var existingCollection = this._hasManyArrays && this._hasManyArrays.find(arr => arr.key === key);
+    if (existingCollection) { return existingCollection; }
     var embedded = meta.options.embedded;
     var polymorphic = meta.options.polymorphic;
     var collectionClass = embedded ? Ember.EmbeddedHasManyArray : Ember.HasManyArray;

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -40,6 +40,8 @@ Ember.hasMany = function(type, options) {
 
 Ember.Model.reopen({
   getHasMany: function(key, type, meta, owner) {
+    var existingCollection = this._hasManyArrays && this._hasManyArrays.find(arr => arr.key === key);
+    if (existingCollection) { return existingCollection; }
     var embedded = meta.options.embedded;
     var polymorphic = meta.options.polymorphic;
     var collectionClass = embedded ? Ember.EmbeddedHasManyArray : Ember.HasManyArray;

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -71,6 +71,31 @@ test("using it in a model definition", function() {
   equal(Ember.run(article, article.get, 'comments.firstObject.token'), 'a');
 });
 
+test("notifyPropertyChange does not alter members", function() {
+  var Comment = Ember.Model.extend({
+        token: Ember.attr(String)
+      }),
+      Article = Ember.Model.extend({
+        comments: Ember.hasMany(Comment, { key: 'comments', embedded: true })
+      });
+
+  var owner = buildOwner();
+  Ember.setOwner(Comment, owner);
+  Ember.setOwner(Article, owner);
+
+  Comment.primaryKey = 'token';
+
+  var article = Article.create();
+
+  equal(article.get('comments.length'), 0);
+  var comment = Comment.create();
+  article.get('comments').pushObject(comment);
+  equal(article.get('comments.length'), 1);
+
+  article.notifyPropertyChange('comments');
+  equal(article.get('comments.length'), 1);
+});
+
 test("model can be specified with a string instead of a class", function() {
   var Article = Ember.Model.extend({
       comments: Ember.hasMany('Ember.CommentModel', { key: 'comments', embedded: true })


### PR DESCRIPTION
`notifyPropertyChange` sometimes needs to be called in order to get component lifecycle hooks to fire for changes to arrays and array-like collections.