### PR TITLE
Obtain classes from store, not owner lookup

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -694,15 +694,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     set(this, '_data', data);
     this.getWithDefault('_dirtyAttributes', []).clear();
 
+    var owner = Ember.getOwner(this);
+    var store = owner.lookup('service:store');
 
     // eagerly load embedded data
     for (let [relationshipKey, relationshipMeta] of this.constructor.relationships) {
-      var owner = Ember.getOwner(this);
 
       if (relationshipMeta.options.embedded && ! relationshipMeta.options.polymorphic) {
         var relationshipType = relationshipMeta.type;
         if (typeof relationshipType === "string") {
-          relationshipType = owner.factoryFor('model:'+ relationshipType).class;
+          relationshipType = store.modelFor(relationshipType);
         }
 
         var relationshipData = data[relationshipKey];

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -124,15 +124,16 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     set(this, '_data', data);
     this.getWithDefault('_dirtyAttributes', []).clear();
 
+    var owner = Ember.getOwner(this);
+    var store = owner.lookup('service:store');
 
     // eagerly load embedded data
     for (let [relationshipKey, relationshipMeta] of this.constructor.relationships) {
-      var owner = Ember.getOwner(this);
 
       if (relationshipMeta.options.embedded && ! relationshipMeta.options.polymorphic) {
         var relationshipType = relationshipMeta.type;
         if (typeof relationshipType === "string") {
-          relationshipType = owner.factoryFor('model:'+ relationshipType).class;
+          relationshipType = store.modelFor(relationshipType);
         }
 
         var relationshipData = data[relationshipKey];

--- a/packages/ember-model/tests/adapter/rest_adapter_test.js
+++ b/packages/ember-model/tests/adapter/rest_adapter_test.js
@@ -813,7 +813,7 @@ test("find() resolves with record", function() {
   expect(1);
 
   var data = {id: 1, name: 'Erik'},
-    record = RESTModel.create();
+    record = RESTModel.create(owner.ownerInjection());
 
   RESTModel.collectionKey = undefined;
   adapter._ajax = function(url, params, method) {
@@ -873,7 +873,7 @@ test("createRecord() resolves with record", function() {
   expect(1);
 
   var data = {id: 1, name: 'Erik'},
-    record = RESTModel.create();
+    record = RESTModel.create(owner.ownerInjection());
 
   RESTModel.rootKey = undefined;
   adapter._ajax = function(url, params, method) {
@@ -890,7 +890,7 @@ test("saveRecord() resolves with record", function() {
   expect(1);
 
   var data = {id: 1, name: 'Erik'},
-    record = RESTModel.create({name: 'Ray'});
+    record = RESTModel.create(owner.ownerInjection(), {name: 'Ray'});
 
   RESTModel.rootKey = undefined;
   adapter._ajax = function(url, params, method) {
@@ -973,7 +973,8 @@ test("didSaveRecord calls normalize", function() {
 
   RESTModel.adapter = adapter;
   RESTModel.rootKey = undefined;
-  var record = Ember.run(RESTModel, RESTModel.create, data);
+  var record = RESTModel.create(owner.ownerInjection(), data);
+
 
   adapter._ajax = function(url, params, method) {
     return ajaxSuccess(data);
@@ -1006,7 +1007,7 @@ test("didCreateRecord calls normalize", function() {
     id: 1,
     name: "Erik"
   };
-  var record = Ember.run(RESTModel, RESTModel.create, data);
+  var record = RESTModel.create(owner.ownerInjection(), data);
 
   adapter._ajax = function(url, params, method) {
     return ajaxSuccess(data);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -26,7 +26,8 @@ test("using it in a model definition", function() {
 
   Article.primaryKey = 'slug';
 
-  var comment = Comment.create();
+  var owner = buildOwner();
+  var comment = Comment.create(owner.ownerInjection());
   Ember.run(comment, comment.load, 1, { article: { slug: 'first-article' } });
   var article = Ember.run(comment, comment.get, 'article');
 
@@ -266,8 +267,10 @@ test("embedded belongsTo CP should handle set", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      author = Author.create();
+  var owner = buildOwner();
+
+  var post = Post.create(owner.ownerInjection()),
+      author = Author.create(owner.ownerInjection());
 
   Ember.run(function() {
     author.load(100, {id: 100});
@@ -296,8 +299,9 @@ test("must be set with value of same type", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      postTwo = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+      postTwo = Post.create(owner.ownerInjection());
 
   Ember.run(function() {
     post.load(1, {id: 1, author_id: null});
@@ -324,8 +328,9 @@ test("relationship type cannot be empty", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-    author = Author.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+    author = Author.create(owner.ownerInjection());
   Ember.run(function() {
     post.load(1, {id: 1, author_id: author});
   });
@@ -375,8 +380,9 @@ test("should be able to set nonembedded relationship to undefined", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      author = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+      author = Post.create(owner.ownerInjection());
 
   Ember.run(function() {
     post.load(1, {id: 1, author_id: 100});
@@ -427,8 +433,9 @@ test("setting relationship should make parent dirty", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      author = Author.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+      author = Author.create(owner.ownerInjection());
 
   Ember.run(function() {
     author.load(100, {id: 100, name: 'bob'});
@@ -457,9 +464,10 @@ test("setting existing nonembedded relationship should make parent dirty", funct
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      author = Author.create(),
-      secondAuthor = Author.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+      author = Author.create(owner.ownerInjection()),
+      secondAuthor = Author.create(owner.ownerInjection());
 
   Ember.run(function() {
     author.load(100, {id: 100, name: 'bob'});
@@ -489,9 +497,10 @@ test("setting existing nonembedded relationship to NULL should make parent dirty
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create(),
-      author = Author.create(),
-      secondAuthor = Author.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection()),
+      author = Author.create(owner.ownerInjection()),
+      secondAuthor = Author.create(owner.ownerInjection());
 
   Ember.run(function() {
     author.load(100, {id: 100, name: 'bob'});
@@ -762,7 +771,8 @@ test("embedded belongsTo with undefined value", function() {
 
   Post.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
   Ember.run(post, post.load, json.id, json);
   equal(post.get('author'), null);
 });

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -159,7 +159,8 @@ test("dirty checking works with boolean attributes", function() {
     canSwim: attr(Boolean)
   });
 
-  var obj = Model.create();
+  var owner = buildOwner();
+  var obj = Model.create(owner.ownerInjection());
   Ember.run(function() {
     obj.load(1, {canSwim: true});
   });
@@ -174,7 +175,9 @@ test("dirty checking works with date attributes", function() {
     createdAt: attr(Date)
   });
   var originalDate = new Date(2013, 0, 0);
-  var obj = Model.create();
+
+  var owner = buildOwner();
+  var obj = Model.create(owner.ownerInjection());
   Ember.run(function() {
     obj.load(1, {createdAt: originalDate.toISOString()});
   });
@@ -208,7 +211,8 @@ test("getting embedded belongsTo attribute after load should not make parent dir
 
   Post.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
   Ember.run(post, post.load, json.id, json);
   equal(post.get('isDirty'), false, 'loaded record for post is not dirty');
 
@@ -226,7 +230,9 @@ test("loading record with embedded hasMany attribute should not make it dirty", 
   });
 
   Post.adapter = Ember.FixtureAdapter.create();
-  var post = Post.create();
+
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
 
   ok(!post.get('comments.isDirty'), "Post comments should be clean initially");
 
@@ -245,7 +251,8 @@ test("isDirty is observable", function() {
     name: attr()
   });
 
-  var obj = Model.create();
+  var owner = buildOwner();
+  var obj = Model.create(owner.ownerInjection());
   Ember.run(function() {
     obj.load(1, {name: 'Erik'});
   });
@@ -359,8 +366,9 @@ test("modifying hasMany record should make parent dirty", function() {
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var author = Author.create();
-  var post = Post.create();
+  var owner = buildOwner();
+  var author = Author.create(owner.ownerInjection());
+  var post = Post.create(owner.ownerInjection());
 
   Ember.run(function() {
     post.load(1, {id: 1, author_ids: [100]});
@@ -386,8 +394,9 @@ test("changing back record in hasMany array should make parent clean again", fun
   Post.adapter = Ember.FixtureAdapter.create();
   Author.adapter = Ember.FixtureAdapter.create();
 
-  var author = Author.create();
-  var post = Post.create();
+  var owner = buildOwner();
+  var author = Author.create(owner.ownerInjection());
+  var post = Post.create(owner.ownerInjection());
 
   Ember.run(function() {
     post.load(1, {id: 1, author_ids: [100]});
@@ -519,7 +528,8 @@ test("modifying embedded belongsTo should make parent dirty", function() {
 
   Post.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
   Ember.run(post, post.load, json.id, json);
   equal(post.get('isDirty'), false, 'post should be clean initially');
 
@@ -547,7 +557,8 @@ test("changing back embedded belongsTo should make parent clean again", function
 
   Post.adapter = Ember.FixtureAdapter.create();
 
-  var post = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
   Ember.run(post, post.load, json.id, json);
 
   var author = post.get('author');
@@ -741,7 +752,8 @@ test("set embedded belongsTo cleans up observers", function() {
     return Ember.meta(obj)._watching['isDirty'] || 0;
   }
 
-  var post = Post.create();
+  var owner = buildOwner();
+  var post = Post.create(owner.ownerInjection());
   Ember.run(post, post.load, json.id, json);
 
   var author = post.get('author');

--- a/packages/ember-model/tests/has_many/embedded_manipulation_test.js
+++ b/packages/ember-model/tests/has_many/embedded_manipulation_test.js
@@ -27,7 +27,7 @@ test("pushing record adds a record to many array", function() {
   Ember.setOwner(Comment, owner);
   Ember.setOwner(Article, owner);
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments');
@@ -72,7 +72,7 @@ test("removing a record from the many array", function() {
   Ember.setOwner(Comment, owner);
   Ember.setOwner(Article, owner);
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments'),

--- a/packages/ember-model/tests/has_many/embedded_objects_load_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_load_test.js
@@ -28,7 +28,7 @@ test("derp", function() {
   Ember.setOwner(Comment, owner);
   Ember.setOwner(Article, owner);
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments');

--- a/packages/ember-model/tests/has_many/embedded_objects_save_test.js
+++ b/packages/ember-model/tests/has_many/embedded_objects_save_test.js
@@ -50,7 +50,7 @@ test("derp", function() {
     }
   };
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments');

--- a/packages/ember-model/tests/has_many/manipulation_test.js
+++ b/packages/ember-model/tests/has_many/manipulation_test.js
@@ -28,7 +28,8 @@ test("pushing record without an id adds a reference to the content", function() 
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments');
@@ -71,7 +72,7 @@ test('adding and reverting an existing record to a many array', function () {
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   equal(article.get('comments.length'), 1, 'should have 1 comment');
@@ -115,13 +116,14 @@ test('adding and reverting a new record to a many array', function () {
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   equal(article.get('comments.length'), 1, 'should have 1 comment');
   equal(article.get('isDirty'), false, 'should not be dirty');
 
-  var newComment = Comment.create({id: 4, text: 'quatro', isNew: true});
+  var newComment = Comment.create(owner.ownerInjection(), {id: 4, text: 'quatro', isNew: true});
   article.get('comments').pushObject(newComment);
 
   equal(article.get('comments.length'), 2, 'should included added comment');
@@ -166,7 +168,7 @@ test("removing a record from the many array", function() {
   Ember.setOwner(Comment, owner);
   Ember.setOwner(Article, owner);
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   var comments = article.get('comments'),
@@ -211,7 +213,8 @@ test("setting a has many array with empty array", function() {
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   equal(article.get('comments.length'), 3, "should be 3 comments");
@@ -254,7 +257,7 @@ test("setting a has many array with item array", function() {
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   equal(article.get('comments.length'), 3, "should be 3 comments");
@@ -297,7 +300,7 @@ test("setting a hasMany array with setObjects", function() {
     {id: 3, text: 'tres'}
   ];
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, json.id, json);
 
   equal(article.get('comments.length'), 3, "should be 3 comments");

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -19,7 +19,8 @@ test("is a CP macro", function() {
 
   ok(cp instanceof Ember.ComputedProperty);
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
   var comments = Ember.run(article, article.get, 'comments');
 
@@ -41,7 +42,8 @@ var Comment = Ember.Model.extend({
 
   ok(cp instanceof Ember.ComputedProperty);
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, 1, {comments: Ember.A([1, 2])});
   var comments = Ember.run(article, article.get, 'comments');
 
@@ -64,7 +66,7 @@ test("using it in a model definition", function() {
 
   Comment.primaryKey = 'token';
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
 
   equal(article.get('comments.length'), 2);
@@ -176,7 +178,8 @@ test("when fetching an association getHasMany is called", function() {
 
   Comment.primaryKey = 'token';
 
-  var article = Article.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection());
   article.getHasMany = function(key, type, meta) {
     equal(key, 'comments', "key passed to getHasMany should be the same as key in hasMany options");
     equal(type, Comment, "type of the association should be passed to getHasMany");
@@ -209,7 +212,7 @@ test("toJSON uses the given relationship key", function() {
 
   Comment.primaryKey = 'token';
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
 
   Ember.run(article, article.load, 1, { comment_ids: Ember.A(['a'] )});
 
@@ -308,8 +311,9 @@ test("relationship type cannot be empty", function() {
 
   Comment.primaryKey = 'token';
 
-  var article = Article.create(),
-     comment = Comment.create();
+  var owner = buildOwner();
+  var article = Article.create(owner.ownerInjection()),
+     comment = Comment.create(owner.ownerInjection());
 
   var comments = [comment];
   Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
@@ -337,7 +341,7 @@ test("key defaults to model's property key", function() {
 
   Comment.adapter = Ember.FixtureAdapter.create();
   Article.adapter = Ember.FixtureAdapter.create();
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
 
   Ember.run(article, article.load, 1, { comments: Ember.A(['a'] )});
 

--- a/packages/ember-model/tests/model_sideloading_test.js
+++ b/packages/ember-model/tests/model_sideloading_test.js
@@ -72,7 +72,7 @@ test("sideloading clears sideload and record cache", function() {
     }
   };
 
-  Model.load([{id: 1, name: "Erik", worth: 123456789}]);
+  Model.load([{id: 1, name: "Erik", worth: 123456789}], owner);
 
   var record;
   Ember.run(function() {
@@ -84,7 +84,7 @@ test("sideloading clears sideload and record cache", function() {
   strictEqual(record.get('name'), "Erik", "Record name retained successfully");
   strictEqual(record.get('worth'), 123456789, "Record worth retained successfully");
 
-  Model.load([{id: 1, name: "Erik", worth: 987654321}]);
+  Model.load([{id: 1, name: "Erik", worth: 987654321}], owner);
 
   Ember.run(function() {
     record = Model.find(1);

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -47,7 +47,7 @@ test("creates reference when creating record", function() {
 test("updates reference and cache when primary key changes", function() {
   expect(7);
 
-  var model = Model.create(),
+  var model = Model.create(owner.ownerInjection()),
       reference = model._reference;
 
   equal(reference.id, undefined, "reference should keep record's id");
@@ -594,7 +594,7 @@ test("toJSON includes embedded relationships", function() {
     author: {id: 1, name: 'drogus'}
   };
 
-  var article = Article.create();
+  var article = Article.create(owner.ownerInjection());
   Ember.run(article, article.load, articleData.id, articleData);
 
   var json = Ember.run(article, article.toJSON);


### PR DESCRIPTION
Because we have customized the store to dynamically lookup models from
schema, rather than the filesystem-based Ember container and registry,
we need to ensure that any lookup of Model classes in Ember model
proceeds from the store service, rather than calling the owner lookup
APIs directly